### PR TITLE
Add Edit article tests and createNewArticle action helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 ./vscode
+.claude/

--- a/src/ui/actions/article/createNewArticle.js
+++ b/src/ui/actions/article/createNewArticle.js
@@ -12,6 +12,10 @@ export async function createNewArticle(page, article) {
     await homePage.clickNewArticleLink();
     await createArticlePage.submitArticleForm(article);
 
+    await page.waitForURL(/\/article\//);
     await viewArticlePage.assertArticleTitleIsVisible(article.title);
+    for (const tag of article.tags) {
+      await viewArticlePage.assertTagIsVisible(tag);
+    }
   });
 }

--- a/src/ui/actions/article/createNewArticle.js
+++ b/src/ui/actions/article/createNewArticle.js
@@ -1,0 +1,17 @@
+import { HomePage } from '../../pages/HomePage';
+import { CreateArticlePage } from '../../pages/article/CreateArticlePage';
+import { ViewArticlePage } from '../../pages/article/ViewArticlePage';
+import { test } from '@playwright/test';
+
+export async function createNewArticle(page, article) {
+  await test.step(`Create new article`, async () => {
+    const homePage = new HomePage(page);
+    const createArticlePage = new CreateArticlePage(page);
+    const viewArticlePage = new ViewArticlePage(page);
+
+    await homePage.clickNewArticleLink();
+    await createArticlePage.submitArticleForm(article);
+
+    await viewArticlePage.assertArticleTitleIsVisible(article.title);
+  });
+}

--- a/src/ui/actions/article/createNewArticle.js
+++ b/src/ui/actions/article/createNewArticle.js
@@ -12,9 +12,9 @@ export async function createNewArticle(page, article) {
     await homePage.clickNewArticleLink();
     await createArticlePage.submitArticleForm(article);
 
-    await page.waitForURL(/\/article\//);
+    await viewArticlePage.waitForArticlePageLoaded();
     await viewArticlePage.assertArticleTitleIsVisible(article.title);
-    for (const tag of article.tags) {
+    for (const tag of article.tags ?? []) {
       await viewArticlePage.assertTagIsVisible(tag);
     }
   });

--- a/src/ui/constants/articleErrorMessages.js
+++ b/src/ui/constants/articleErrorMessages.js
@@ -1,1 +1,4 @@
 export const TITLE_CANNOT_BE_EMPTY = 'Article title cannot be empty';
+export const DESCRIPTION_CANNOT_BE_EMPTY =
+  'Article description cannot be empty';
+export const TEXT_CANNOT_BE_EMPTY = 'Article body cannot be empty';

--- a/src/ui/pages/article/EditArticlePage.js
+++ b/src/ui/pages/article/EditArticlePage.js
@@ -13,8 +13,10 @@ export class EditArticlePage {
     this.errorMessage = page.getByRole('list').nth(1);
   }
 
-  getTagPill(tag) {
-    return this.page.locator('.tag-default', { hasText: tag });
+  async getTagPill(tag) {
+    return await test.step(`Get the '${tag}' tag pill`, async () =>
+      this.page.locator('.tag-default', { hasText: tag }),
+    );
   }
 
   async fillTitleField(title) {
@@ -62,7 +64,8 @@ export class EditArticlePage {
 
   async removeTag(tag) {
     await test.step(`Remove the '${tag}' tag`, async () => {
-      await this.getTagPill(tag).locator('i.ion-close-round').click();
+      const pill = await this.getTagPill(tag);
+      await pill.locator('i.ion-close-round').click();
     });
   }
 

--- a/src/ui/pages/article/EditArticlePage.js
+++ b/src/ui/pages/article/EditArticlePage.js
@@ -1,20 +1,24 @@
 import { expect, test } from '@playwright/test';
 
-export class CreateArticlePage {
+export class EditArticlePage {
   constructor(page) {
     this.page = page;
     this.titleField = page.getByPlaceholder('Article Title');
     this.descriptionField = page.getByPlaceholder(`What's this article about?`);
     this.textField = page.getByPlaceholder('Write your article (in markdown)');
     this.tagsField = page.getByPlaceholder('Enter tags');
-    this.publishArticleButton = page.getByRole('button', {
-      name: 'Publish Article',
+    this.updateArticleButton = page.getByRole('button', {
+      name: 'Update Article',
     });
     this.errorMessage = page.getByRole('list').nth(1);
   }
 
+  getTagPill(tag) {
+    return this.page.locator('.tag-default', { hasText: tag });
+  }
+
   async fillTitleField(title) {
-    await test.step(`Fill the 'Title' field`, async () => {
+    await test.step(`Fill the 'Title' field with '${title}'`, async () => {
       await this.titleField.fill(title);
     });
   }
@@ -31,9 +35,21 @@ export class CreateArticlePage {
     });
   }
 
-  async clickPublishArticleButton() {
-    await test.step(`Click the 'Publish Article' button`, async () => {
-      await this.publishArticleButton.click();
+  async clearTitleField() {
+    await test.step(`Clear the 'Title' field`, async () => {
+      await this.titleField.fill('');
+    });
+  }
+
+  async clearDescriptionField() {
+    await test.step(`Clear the 'Description' field`, async () => {
+      await this.descriptionField.fill('');
+    });
+  }
+
+  async clearTextField() {
+    await test.step(`Clear the 'Text' field`, async () => {
+      await this.textField.fill('');
     });
   }
 
@@ -44,21 +60,21 @@ export class CreateArticlePage {
     });
   }
 
-  async addTags(tags) {
-    await test.step(`Add tags`, async () => {
-      for (const tag of tags) {
-        await this.addTag(tag);
-      }
+  async removeTag(tag) {
+    await test.step(`Remove the '${tag}' tag`, async () => {
+      await this.getTagPill(tag).locator('i.ion-close-round').click();
     });
   }
 
-  async submitArticleForm(article) {
-    await test.step(`Fill the 'New Article' form`, async () => {
-      await this.fillTitleField(article.title);
-      await this.fillDescriptionField(article.description);
-      await this.fillTextField(article.text);
-      await this.addTags(article.tags ?? []);
-      await this.clickPublishArticleButton();
+  async clickUpdateArticleButton() {
+    await test.step(`Click the 'Update Article' button`, async () => {
+      await this.updateArticleButton.click();
+    });
+  }
+
+  async assertDescriptionFieldValue(description) {
+    await test.step(`Assert the 'Description' field value`, async () => {
+      await expect(this.descriptionField).toHaveValue(description);
     });
   }
 

--- a/src/ui/pages/article/ViewArticlePage.js
+++ b/src/ui/pages/article/ViewArticlePage.js
@@ -4,17 +4,46 @@ export class ViewArticlePage {
   constructor(page) {
     this.page = page;
     this.articleTitleHeader = page.getByRole('heading');
+    this.editArticleLink = page.getByRole('link', { name: 'Edit Article' });
+    this.tagList = page.locator('.tag-list');
+  }
+
+  async clickEditArticleButton() {
+    await test.step(`Click the 'Edit Article' button`, async () => {
+      await this.editArticleLink.first().click();
+      await this.page.waitForURL(/\/editor\//);
+    });
+  }
+
+  async waitForArticlePageLoaded() {
+    await test.step(`Wait for the article page to load`, async () => {
+      await this.page.waitForURL(/\/article\//);
+      await this.page.reload();
+      await this.editArticleLink.first().waitFor();
+    });
   }
 
   async assertArticleTitleIsVisible(title) {
-    await test.step(`Assert the article has correct title'`, async () => {
+    await test.step(`Assert the article has the '${title}' title`, async () => {
       await expect(this.articleTitleHeader).toContainText(title);
     });
   }
 
   async assertArticleTextIsVisible(text) {
-    await test.step(`Assert the article has correct text'`, async () => {
+    await test.step(`Assert the article has correct text`, async () => {
       await expect(this.page.getByText(text)).toBeVisible();
+    });
+  }
+
+  async assertTagIsVisible(tag) {
+    await test.step(`Assert the '${tag}' tag is visible`, async () => {
+      await expect(this.tagList.getByText(tag, { exact: true })).toBeVisible();
+    });
+  }
+
+  async assertTagIsNotVisible(tag) {
+    await test.step(`Assert the '${tag}' tag is not visible`, async () => {
+      await expect(this.tagList.getByText(tag, { exact: true })).toBeHidden();
     });
   }
 }

--- a/tests/editArticle/editArticle.spec.js
+++ b/tests/editArticle/editArticle.spec.js
@@ -1,0 +1,156 @@
+import { test } from '@playwright/test';
+import { EditArticlePage } from '../../src/ui/pages/article/EditArticlePage';
+import { ViewArticlePage } from '../../src/ui/pages/article/ViewArticlePage';
+import { generateNewUserData } from '../../src/common/testData/generateNewUserData';
+import { generateNewArticleData } from '../../src/common/testData/generateNewArticleData';
+import { signUpUser } from '../../src/ui/actions/auth/signUpUser';
+import { createNewArticle } from '../../src/ui/actions/article/createNewArticle';
+import {
+  TITLE_CANNOT_BE_EMPTY,
+  DESCRIPTION_CANNOT_BE_EMPTY,
+  TEXT_CANNOT_BE_EMPTY,
+} from '../../src/ui/constants/articleErrorMessages';
+
+test.describe('Edit article for an article with a tag', () => {
+  let viewArticlePage;
+  let editArticlePage;
+  let article;
+  let updatedArticle;
+
+  test.beforeEach(async ({ page }) => {
+    viewArticlePage = new ViewArticlePage(page);
+    editArticlePage = new EditArticlePage(page);
+    article = generateNewArticleData(1);
+    updatedArticle = generateNewArticleData(1);
+
+    const user = generateNewUserData();
+    await signUpUser(page, user);
+    await createNewArticle(page, article);
+    await viewArticlePage.clickEditArticleButton();
+  });
+
+  test('Edit the article title for the existing article', async () => {
+    await editArticlePage.fillTitleField(updatedArticle.title);
+    await editArticlePage.clickUpdateArticleButton();
+
+    await viewArticlePage.waitForArticlePageLoaded();
+    await viewArticlePage.assertArticleTitleIsVisible(updatedArticle.title);
+  });
+
+  test('Edit the article description for the existing article', async () => {
+    await editArticlePage.fillDescriptionField(updatedArticle.description);
+    await editArticlePage.clickUpdateArticleButton();
+
+    await viewArticlePage.waitForArticlePageLoaded();
+    await viewArticlePage.clickEditArticleButton();
+    await editArticlePage.assertDescriptionFieldValue(
+      updatedArticle.description,
+    );
+  });
+
+  test('Edit the article text for the existing article', async () => {
+    await editArticlePage.fillTextField(updatedArticle.text);
+    await editArticlePage.clickUpdateArticleButton();
+
+    await viewArticlePage.waitForArticlePageLoaded();
+    await viewArticlePage.assertArticleTextIsVisible(updatedArticle.text);
+  });
+
+  test('Add the tag for the existing article with tags', async () => {
+    const [newTag] = updatedArticle.tags;
+    const [originalTag] = article.tags;
+
+    await editArticlePage.addTag(newTag);
+    await editArticlePage.clickUpdateArticleButton();
+
+    await viewArticlePage.waitForArticlePageLoaded();
+    await viewArticlePage.assertTagIsVisible(newTag);
+    await viewArticlePage.assertTagIsVisible(originalTag);
+  });
+
+  test('Remove an article tag for the existing article with tag', async () => {
+    const [originalTag] = article.tags;
+
+    await editArticlePage.removeTag(originalTag);
+    await editArticlePage.clickUpdateArticleButton();
+
+    await viewArticlePage.waitForArticlePageLoaded();
+    await viewArticlePage.assertTagIsNotVisible(originalTag);
+  });
+
+  test('Remove an article title for the existing article', async () => {
+    await editArticlePage.clearTitleField();
+    await editArticlePage.clickUpdateArticleButton();
+
+    await editArticlePage.assertErrorMessageContainsText(
+      TITLE_CANNOT_BE_EMPTY,
+    );
+  });
+
+  test('Remove an article description for the existing article', async () => {
+    await editArticlePage.clearDescriptionField();
+    await editArticlePage.clickUpdateArticleButton();
+
+    await editArticlePage.assertErrorMessageContainsText(
+      DESCRIPTION_CANNOT_BE_EMPTY,
+    );
+  });
+
+  test('Remove the article text for the existing article', async () => {
+    await editArticlePage.clearTextField();
+    await editArticlePage.clickUpdateArticleButton();
+
+    await editArticlePage.assertErrorMessageContainsText(TEXT_CANNOT_BE_EMPTY);
+  });
+
+  test('Editing the title preserves the original tag', async () => {
+    const [originalTag] = article.tags;
+
+    await editArticlePage.fillTitleField(updatedArticle.title);
+    await editArticlePage.clickUpdateArticleButton();
+
+    await viewArticlePage.waitForArticlePageLoaded();
+    await viewArticlePage.assertArticleTitleIsVisible(updatedArticle.title);
+    await viewArticlePage.assertTagIsVisible(originalTag);
+  });
+
+  test('Edit all article fields at once', async () => {
+    await editArticlePage.fillTitleField(updatedArticle.title);
+    await editArticlePage.fillDescriptionField(updatedArticle.description);
+    await editArticlePage.fillTextField(updatedArticle.text);
+    await editArticlePage.clickUpdateArticleButton();
+
+    await viewArticlePage.waitForArticlePageLoaded();
+    await viewArticlePage.assertArticleTitleIsVisible(updatedArticle.title);
+    await viewArticlePage.assertArticleTextIsVisible(updatedArticle.text);
+  });
+});
+
+test.describe('Edit article for an article without tags', () => {
+  let viewArticlePage;
+  let editArticlePage;
+  let article;
+  let updatedArticle;
+
+  test.beforeEach(async ({ page }) => {
+    viewArticlePage = new ViewArticlePage(page);
+    editArticlePage = new EditArticlePage(page);
+    article = generateNewArticleData();
+    updatedArticle = generateNewArticleData(1);
+
+    const user = generateNewUserData();
+    await signUpUser(page, user);
+    await createNewArticle(page, article);
+    await viewArticlePage.clickEditArticleButton();
+  });
+
+  test('Add the tag for the existing article without tags', async () => {
+    const [newTag] = updatedArticle.tags;
+
+    await editArticlePage.addTag(newTag);
+    await editArticlePage.clickUpdateArticleButton();
+
+    await viewArticlePage.waitForArticlePageLoaded();
+    await viewArticlePage.assertTagIsVisible(newTag);
+  });
+});


### PR DESCRIPTION
## Summary

Implements both tasks from the README:

### Task 1 — `createNewArticle` action
- New `src/ui/actions/article/createNewArticle.js` modelled after `signUpUser`.
- `CreateArticlePage` extended with tags field, `addTag`, `addTags`, `submitArticleForm`. The action handles both tagged and untagged articles (falls back to `[]` when `article.tags` is undefined).

### Task 2 — Edit article tests
- New `tests/editArticle/editArticle.spec.js` with 11 tests:
  - Edit title / description / text
  - Add tag (to article with and without existing tags)
  - Remove tag
  - Remove title / description / text (with error-message assertions)
  - Extras: editing the title preserves the original tag; editing all fields at once.
- `test.step` is applied to every page-object method (new `EditArticlePage` and additions to `ViewArticlePage`).
- Error messages live in `src/ui/constants/articleErrorMessages.js` (`TITLE_CANNOT_BE_EMPTY`, `DESCRIPTION_CANNOT_BE_EMPTY`, `TEXT_CANNOT_BE_EMPTY`).
- Preconditions use `generateNewUserData` + `signUpUser` + `createNewArticle`.

### Notes
- The Mate Academy Conduit fork keeps the slug stable on title change and does not auto-refetch the article on the view page after an edit. `ViewArticlePage.waitForArticlePageLoaded` issues a `page.reload()` to get a fresh view before assertions.
- `.claude/` added to `.gitignore` (local Claude Code tooling directory).

## Test plan
- [x] `npx playwright test tests/editArticle` — 11/11 passing
- [x] `npx eslint tests/ src/` — clean